### PR TITLE
Plane: tailsitter: add gains to scale control surface vs motors

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -559,6 +559,24 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Range: 10 500
     AP_GROUPINFO("TAILSIT_RAT_VT", 25, QuadPlane, tailsitter.transition_rate_vtol, 50),
 
+    // @Param: TAILSIT_VT_R_P
+    // @DisplayName: Tailsitter VTOL control surface roll gain
+    // @Description: Scale from PID output to control surface, for use where a single axis is actuated by both motors and Tilt/control surface on a copter style tailsitter, increase to favor control surfaces and reduce motor output by reducing gains
+    // @Range: 0 2
+    AP_GROUPINFO("TAILSIT_VT_R_P", 26, QuadPlane, tailsitter.VTOL_roll_scale, 1),
+
+    // @Param: TAILSIT_VT_P_P
+    // @DisplayName: Tailsitter VTOL control surface pitch gain
+    // @Description: Scale from PID output to control surface, for use where a single axis is actuated by both motors and Tilt/control surface on a copter style tailsitter, increase to favor control surfaces and reduce motor output by reducing gains
+    // @Range: 0 2
+    AP_GROUPINFO("TAILSIT_VT_P_P", 27, QuadPlane, tailsitter.VTOL_pitch_scale, 1),
+
+    // @Param: TAILSIT_VT_Y_P
+    // @DisplayName: Tailsitter VTOL control surface yaw gain
+    // @Description: Scale from PID output to control surface, for use where a single axis is actuated by both motors and Tilt/control surface on a copter style tailsitter, increase to favor control surfaces and reduce motor output by reducing gains
+    // @Range: 0 2
+    AP_GROUPINFO("TAILSIT_VT_Y_P", 28, QuadPlane, tailsitter.VTOL_yaw_scale, 1),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -581,6 +581,9 @@ private:
         AP_Float scaling_speed_max;
         AP_Int16 gain_scaling_mask;
         AP_Float disk_loading;
+        AP_Float VTOL_roll_scale;
+        AP_Float VTOL_pitch_scale;
+        AP_Float VTOL_yaw_scale;
     } tailsitter;
 
     // return the transition_angle_vtol value

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -164,9 +164,9 @@ void QuadPlane::tailsitter_output(void)
     plane.rollController.reset_I();
 
     // pull in copter control outputs
-    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, (motors->get_yaw()+motors->get_yaw_ff())*-SERVO_MAX);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, (motors->get_pitch()+motors->get_pitch_ff())*SERVO_MAX);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, (motors->get_roll()+motors->get_roll_ff())*SERVO_MAX);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, (motors->get_yaw()+motors->get_yaw_ff())*-SERVO_MAX*tailsitter.VTOL_yaw_scale);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, (motors->get_pitch()+motors->get_pitch_ff())*SERVO_MAX*tailsitter.VTOL_pitch_scale);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, (motors->get_roll()+motors->get_roll_ff())*SERVO_MAX*tailsitter.VTOL_roll_scale);
 
     if (hal.util->get_soft_armed()) {
         // scale surfaces for throttle


### PR DESCRIPTION
This adds gain params for roll, pitch and yaw to scale how much the control surfaces move relative to the motor outputs. 

Note that there are some big structural changes to tailsitter between this and 4.2.dev. So the param conversion from this to 4.2 will not work. Just something to watch out for when you upgrade. 